### PR TITLE
Allow for forcing index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Provides advanced mongo indexing options for sails.js models that use the sails-
 
 ## Usage
 
-    npm i sails-hook-mongoat
+```bash
+npm install git+ssh://git@github.com/fpm-git/sails-hook-mongoat.git
+```
 
 Then simply add an 'indexes' array property to your sails model(s) that you want to add custom indexers on.  This contains all your indexes.
 
@@ -18,63 +20,75 @@ Index properties:
 
 ## Examples ##
 
-**Creating a 'expires after' index**
-```javascript
+### Creating a TTL index:
+```js
 // MY MODEL WITH A DATE FIELD
 module.exports = {
   attributes: {
     myDate: {
       type: 'date',
-      required: true
-    }
+      required: true,
+    },
   },
-  indexes: [
-    {
-      attributes: {
-        myDate: 1
-      },
-      options: {
-        expireAfterSeconds: 60  // expire 60s after myDate
-      }
-    }
-  ]
+  indexes: [{
+    attributes: {
+      myDate: 1,
+    },
+    options: {
+      expireAfterSeconds: 60,  // expire 60s after myDate
+    },
+  }],
 };
 ```
 
 
-**Creating a composite unique index**
-```javascript
+### Creating a composite unique index:
+```js
 // MY EVENTS MODEL
 module.exports = {
   attributes: {
     event_id: {
       type: 'integer',
-      required: true
+      required: true,
     },
     match_id: {
       type: 'integer',
-      required: true
-    }
+      required: true,
+    },
   },
-  indexes: [
-    //event & match composite index
-    {
-      attributes: {
-        event_id: -1,    // desc
-        match: 1         // asc
-      },
-      options: {
-        unique: true
-      }
-    }
-  ]
+  indexes: [{
+    // Index on both `event_id` and `match`.
+    attributes: {
+      event_id: -1,    // desc
+      match: 1,        // asc
+    },
+    options: {
+      unique: true,
+    },
+  }],
 };
 ```
 
-## Maintained By
-- [Mike Diarmid](https://github.com/salakar)
+### Forcing updates to run in `safe` migration mode:
 
-<img src='http://i.imgur.com/NsAdNdJ.png'>
+Sometimes it might be desireable to run migrations in safe mode, something which is automatically prevented by default. In such scenarios, switching to `drop` or `alter` may not entirely be an option.
+
+For these cases, the `mongoat.forceUpdate` config value may be set to a truthy value, forcing the hook to attempt updates regardless of model migration preference.
+
+This flag may be set conveniently through the commandline when launching your Sails app:
+
+```bash
+# With Sails running in console mode:
+$ sails console --mongoat.forceUpdate
+
+# Or run Sails without the REPL:
+$ sails lift --mongoat.forceUpdate
+
+# Or run Sails directly:
+$ node ./node_modules/.bin/sails lift --mongoat.forceUpdate
+```
+
+
 
 [npm-image]: https://img.shields.io/npm/v/sails-hook-mongoat.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/sails-hook-mongoat

--- a/index.js
+++ b/index.js
@@ -17,18 +17,19 @@ const SailsHookMongoat = (sails) => ({
    * createModelIndexes method for each.
    */
   async createAllIndexes() {
-    sails.log.debug('Mongoat: creating model indexes...');
-
-    // leave without applying indices, if we're not using an 'alter' or 'drop' strategy
-    if (sails.config.models && (['alter', 'drop'].indexOf(sails.config.models.migrate) < 0)) {
-      sails.log.warn(`Mongoat: not creating indexes due to model migration strategy "${sails.config.models.migrate}". Use "alter" or "drop" to enable index creation, or build them manually.`);
+    // Determine whether or not we should create indexes (and get a fitting reason if not).
+    const createPrefs = this.shouldCreateIndexes();
+    if (!createPrefs.shouldCreate) {
+      sails.log.warn('[Mongoat]', 'Not creating indexes:', createPrefs.forbiddenReason);
       return;
     }
 
+    sails.log.debug('[Mongoat]', 'Handling model index updates...');
     // load indices for each model. we wait for each "synchronously," but Mongo doesn't parallelise it anyway (by default)... (and we wouldn't want to break guarantees by doing that either)
     for (modelName in sails.models) {
       await this.createModelIndexes(sails.models[modelName]);
     }
+    sails.log.debug('[Mongoat]', 'Done updating indexes!');
   },
 
   /**
@@ -59,6 +60,44 @@ const SailsHookMongoat = (sails) => ({
         sails.log.error(`Mongoat: failed to create index for model "${model.tableName}":`, e);
       }
     });
+  },
+
+  /**
+   * @typedef {object} ShouldCreateIndexInfo
+   * @property {boolean} shouldCreate - Whether or not index updates should be performed.
+   * @property {string} [forbiddenReason] - Reason for which indexes should not be updated.
+   * Must be set when `canCreate` is `false`.
+   */
+  /**
+   * Determines whether or not we are allowed to create or update new indexes, returning
+   * an object with fitting error details in the event where something would prevent our
+   * attempted changes.
+   *
+   * By default, index updates are forbidden when not running in `alter` or `drop` mode,
+   * though this may be overridden by specifying a truthy `mongoat.forceUpdate` value in
+   * the config.
+   *
+   * One convenient way to ensure indexes are updated is to simply pass the force-update
+   * flag when lifting:
+   * `sails console --mongoat.forceUpdate`
+   *
+   * @returns {ShouldCreateIndexInfo}
+   */
+  shouldCreateIndexes() {
+    // If we've mongoat configured to force updates, return immediately indicating we're
+    // allowed.
+    if (sails.config.mongoat && sails.config.mongoat.forceUpdate) {
+      return { shouldCreate: true };
+    }
+    // If we're not in `alter` or `drop` mode, avoid updates.
+    if (sails.config.models && !['alter', 'drop'].includes(sails.config.models.migrate)) {
+      return {
+        shouldCreate: false,
+        forbiddenReason: `Model migration strategy "${sails.config.models.migrate}" was set. Use "alter" or "drop" to enable index creation, or build them manually.`,
+      };
+    }
+    // Otherwise we're good to go ahead and create/update indexes!
+    return { shouldCreate: true };
   },
 
 });

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const SailsHookMongoat = (sails) => ({
     const createPrefs = this.shouldCreateIndexes();
     if (!createPrefs.shouldCreate) {
       sails.log.warn('[Mongoat]', 'Not creating indexes:', createPrefs.forbiddenReason);
+      sails.log.warn('[Mongoat]', 'If desired, index updates can be instead forced with the "--mongoat.forceUpdate" commandline option. See README for more info.');
       return;
     }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const SailsHookMongoat = (sails) => ({
 
   initialize(done) {
     sails.after('hook:orm:loaded', () => {
-      this.createAllIndexes().then(res => done()).catch(done);
+      this.createAllIndexes().then(() => done()).catch(done);
     });
   },
 
@@ -26,7 +26,7 @@ const SailsHookMongoat = (sails) => ({
 
     sails.log.debug('[Mongoat]', 'Handling model index updates...');
     // load indices for each model. we wait for each "synchronously," but Mongo doesn't parallelise it anyway (by default)... (and we wouldn't want to break guarantees by doing that either)
-    for (modelName in sails.models) {
+    for (const modelName in sails.models) {
       await this.createModelIndexes(sails.models[modelName]);
     }
     sails.log.debug('[Mongoat]', 'Done updating indexes!');


### PR DESCRIPTION
This PR adds a config option which allows for forcing index creation in scenarios where it would otherwise be blocked.

Most notably, indexes can now be created regardless of model migration preference, provided the force-update flag is set.

The flag may be easily supplied via commandline option:
```bash
sails console --mongoat.forceUpdate
```

(readme has been [updated](https://github.com/fpm-git/sails-hook-mongoat/blob/dde660bd98f25cec5feb18ee29df4b43120de5f1/README.md#forcing-updates-to-run-in-safe-migration-mode) to reflect this new capability)